### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Seeed Studio
 maintainer=Seeed Studio <techsupport@seeed.cc>
 sentence=Arduino library of Grove - Motor Driver(TB6612FNG)
 paragraph=Arduino library of Grove - Motor Driver(TB6612FNG)
-category=Actuators
+category=Device Control
 url=https://github.com/Seeed-Studio/Grove_Motor_Driver_TB6612FNG.git
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Actuators' in library Grove - Motor Driver TB6612FNG is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format